### PR TITLE
enhance newrelic module build

### DIFF
--- a/packages/newrelic/.npmignore
+++ b/packages/newrelic/.npmignore
@@ -1,0 +1,3 @@
+/*
+!dist/
+dist/__mocks__/*

--- a/packages/newrelic/package.json
+++ b/packages/newrelic/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "jest",
     "test:cov": "jest --coverage",
-    "build": "rimraf dist && tsc && yarn copy-files",
+    "build": "rimraf dist && tsc",
     "copy-files": "node ../../scripts/copy-files-to-dist.js",
     "prepublish": "npm run build"
   },

--- a/packages/newrelic/tsconfig.json
+++ b/packages/newrelic/tsconfig.json
@@ -15,5 +15,5 @@
       "@sl-nestjs-modules/newrelic": ["src/index"],
     }
   },
-  "exclude": ["node_modules", "dist", "jest.setup.ts"]
+  "exclude": ["node_modules", "dist", "jest.setup.ts", "src/**/*.spec.ts"]
 }


### PR DESCRIPTION
- 只將需要的檔案推到 npm 上
  - 不需要 .spec 等測試檔
  - 只需要 build 完後的 dist，但不需要 `dist/__mocks__/*`
  - 不需要重複的 packge.json , readme, license 在  dist 中

- run `yarn build && npm pack` 後的結果
<img width="981" alt="Screen Shot 2022-07-01 at 09 44 22" src="https://user-images.githubusercontent.com/23053211/176806082-bac0d46d-845a-42e2-8af7-19d0435517dd.png">

